### PR TITLE
Add support for nested variables

### DIFF
--- a/syntaxes/rainmeter.tmLanguage.json
+++ b/syntaxes/rainmeter.tmLanguage.json
@@ -19,6 +19,9 @@
       "include": "#variables"
     },
     {
+      "include": "#nestedvariables"
+    },
+    {
       "include": "#comments"
     }
   ],
@@ -60,7 +63,7 @@
     },
     "entities": {
       "name": "entity.name.type.rainmeter",
-      "begin": "\\[",
+      "begin": "\\[[^#%&\\$]",
       "end": "\\]",
       "patterns": [
         {
@@ -82,6 +85,17 @@
         {
           "name": "constant.numeric.rainmeter",
           "match": "\\d"
+        }
+      ]
+    },
+    "nestedvariables": {
+      "name": "variable.parameter.rainmeter.nested",
+      "begin": "\\[[#%&\\$]",
+      "end": "\\]",
+      "patterns": [
+        {
+          "name": "variable.parameter.rainmeter.nested",
+          "include": "#nestedvariables"
         }
       ]
     },


### PR DESCRIPTION
Added support for [Nesting Variables](https://docs.rainmeter.net/manual/variables/nesting-variables/).

Before:

![image](https://user-images.githubusercontent.com/5422593/46930084-65b50000-cff8-11e8-964e-cabbd7e15872.png)

After:

![image](https://user-images.githubusercontent.com/5422593/46930124-9eed7000-cff8-11e8-8911-1cbc7e09fb56.png)
