### PR TITLE
Fix Nested Variables highlighting when contained in a string

### DIFF
--- a/syntaxes/rainmeter.tmLanguage.json
+++ b/syntaxes/rainmeter.tmLanguage.json
@@ -58,6 +58,10 @@
         {
           "name": "variable.parameter.rainmeter",
           "include": "#variables"
+        },
+        {
+          "name": "variable.parameter.rainmeter.nested",
+          "include": "#nestedvariables"
         }
       ]
     },


### PR DESCRIPTION
Nested variables weren't being highlighted correctly when they were contained within strings. This is fixed simply by adding the nested variables regex to the strings group. Now, it works!

Before:
![2019-02-16 19_54_23](https://user-images.githubusercontent.com/3515394/52907795-1987ff80-3226-11e9-941d-486e35e2425e.png)
After:
![2019-02-16 20_04_23](https://user-images.githubusercontent.com/3515394/52907796-1987ff80-3226-11e9-8252-e7e5cbe3e87e.png)
(note that I have the rainbow brackets extension installed, which overrides the bracket and parenthesis highlighting)